### PR TITLE
Add symlink support

### DIFF
--- a/src/npm/hash-and-cache.js
+++ b/src/npm/hash-and-cache.js
@@ -65,6 +65,7 @@ module.exports = async function (options) {
         file: tarPath,
         strict: true,
         gzip: true,
+        noDirRecurse: true,
         cwd: options.outputPath
       }
 
@@ -96,7 +97,9 @@ var generateHash = function (sourcePath, sourceFiles, sourceIgnore, hashSuffix, 
   });
 
   hashAlgorithm.update(hashSuffix);
-  hashAlgorithm.update(execCommand);
+  if (execCommand) {
+    hashAlgorithm.update(execCommand);
+  }
 
   var hash = hashAlgorithm.digest('hex');
 
@@ -116,7 +119,7 @@ var getFileList = function (workingDirectory, globs, ignoreGlob) {
   var globOptions = {
     cwd: workingDirectory,
     dot: true,
-    nodir: true,
+    nodir: false,
     ignore: ignoreGlob
   }
 
@@ -240,6 +243,7 @@ var extractCache = function (targetPath, hash) {
     sync: true,
     file: tarPath,
     strict: true,
+    preservePaths: true,
     cwd: targetPath
   }
 

--- a/src/vsts/buildAndReleaseTask/hash-and-cache.js
+++ b/src/vsts/buildAndReleaseTask/hash-and-cache.js
@@ -65,6 +65,7 @@ module.exports = async function (options) {
         file: tarPath,
         strict: true,
         gzip: true,
+        noDirRecurse: true,
         cwd: options.outputPath
       }
 
@@ -96,7 +97,9 @@ var generateHash = function (sourcePath, sourceFiles, sourceIgnore, hashSuffix, 
   });
 
   hashAlgorithm.update(hashSuffix);
-  hashAlgorithm.update(execCommand);
+  if (execCommand) {
+    hashAlgorithm.update(execCommand);
+  }
 
   var hash = hashAlgorithm.digest('hex');
 
@@ -116,7 +119,7 @@ var getFileList = function (workingDirectory, globs, ignoreGlob) {
   var globOptions = {
     cwd: workingDirectory,
     dot: true,
-    nodir: true,
+    nodir: false,
     ignore: ignoreGlob
   }
 
@@ -240,6 +243,7 @@ var extractCache = function (targetPath, hash) {
     sync: true,
     file: tarPath,
     strict: true,
+    preservePaths: true,
     cwd: targetPath
   }
 


### PR DESCRIPTION
* `nodir: true` in `globOptions` allows glob to include symlinks in the return list, as they are treated as directories. 
* Then, to not explode the `.tgz` file, I've set `noDirRecurse: true`, which means node-tar will only include the files explicitly referenced in the `files` list. Directories (i.e. symlinks) will then only be included as empty directories. The `files` list includes a complete list of all the files to be archived, so this option shouldn't create any regressions.
* Finally, I've set `preservePaths: true` to output symlinks correctly on `tar.extract`.