### PR TITLE
Gracefully fail on cache update failure

### DIFF
--- a/src/vsts/buildAndReleaseTask/task.js
+++ b/src/vsts/buildAndReleaseTask/task.js
@@ -98,8 +98,13 @@ var hashAndCache = function (options) {
           }
     
           tar.create(tarOptions, files);
-          uploadCache(tarPath, tarFile, options.storageAccount, options.storageContainer, options.storageKey).then(function() {
+          uploadCache(tarPath, tarFile, options.storageAccount, options.storageContainer, options.storageKey)
+          .then(function() {
             fs.unlinkSync(tarPath);
+          })
+          .catch(function(err) {
+            console.warn("Uploading of cache failed. This may happen when attempting to upload in parallel.")
+            console.warn(err);
           });
         }
       }


### PR DESCRIPTION
If two same-named caches are being uploaded concurrently, the blob will reject one of them, failing the step. Failed cache updates should always fail gracefully (especially in the race condition case where it is still uploaded).