### PR TITLE
Adding in ##VSO set variable for cache hit/miss and execCommand control option. 

### DIFF
--- a/src/vsts/buildAndReleaseTask/hash-and-cache.js
+++ b/src/vsts/buildAndReleaseTask/hash-and-cache.js
@@ -29,6 +29,7 @@ module.exports = async function (options) {
 
   if (await doesCacheExist(hash, options.storageAccount, options.storageContainer, options.storageKey)) {
     console.log("CACHE HIT!");
+    console.log("##vso[task.setvariable variable=cacheHit]true");
 
     if (options.downloadCacheOnHit) {
       try {
@@ -43,6 +44,7 @@ module.exports = async function (options) {
   }
 
   console.log("CACHE MISS!");
+  console.log("##vso[task.setvariable variable=cacheHit]false");
 
   if (options.execCommand) {
     console.log("Running Command " + options.execCommand);

--- a/src/vsts/buildAndReleaseTask/hash-and-cache.js
+++ b/src/vsts/buildAndReleaseTask/hash-and-cache.js
@@ -58,7 +58,7 @@ module.exports = async function (options) {
     }
   }
 
-  if (options.uploadCacheOnMiss) {
+  if (options.uploadCacheOnMiss && !options.skipExec) {
     var files = getFileList(options.outputPath, options.outputFiles, options.outputIgnore);
 
     if (!files || files.length == 0) {
@@ -84,6 +84,10 @@ module.exports = async function (options) {
     tar.create(tarOptions, files);
     await uploadCache(tarPath, tarFile, options.storageAccount, options.storageContainer, options.storageKey);
     fs.unlinkSync(tarPath);
+  } else {
+    if (options.skipExec) {
+      console.log("Skipping cache upload, no output to upload (options.skipExec = true)");
+    }
   }
 }
 

--- a/src/vsts/buildAndReleaseTask/hash-and-cache.js
+++ b/src/vsts/buildAndReleaseTask/hash-and-cache.js
@@ -24,6 +24,7 @@ module.exports = async function (options) {
   if (typeof options.outputFiles === 'string') options.outputFiles = [options.outputFiles];
   options.downloadCacheOnHit = options.downloadCacheOnHit === false ? false : true;
   options.uploadCacheOnMiss = options.uploadCacheOnMiss === true;
+  options.skipExec = options.skipExec === true? true : false;
 
   var hash = generateHash(options.sourcePath, options.sourceFiles, options.sourceIgnore, options.hashSuffix, options.execCommand);
 
@@ -46,11 +47,15 @@ module.exports = async function (options) {
   console.log("CACHE MISS!");
   console.log("##vso[task.setvariable variable=cacheHit]false");
 
-  if (options.execCommand) {
+  if (options.execCommand && !options.skipExec) {
     console.log("Running Command " + options.execCommand);
     execSync(options.execCommand, { cwd: options.execWorkingDirectory, stdio: 'inherit' });
   } else {
-    console.log("No command specified - skipping");
+    if (options.skipExec) {
+      console.log("Skipping exec command (options.skipExec = true)");
+    } else {
+      console.log("No command specified - skipping");
+    }
   }
 
   if (options.uploadCacheOnMiss) {

--- a/src/vsts/buildAndReleaseTask/task.js
+++ b/src/vsts/buildAndReleaseTask/task.js
@@ -63,6 +63,7 @@ var hashAndCache = function (options) {
   doesCacheExist(hash, options.storageAccount, options.storageContainer, options.storageKey).then(function (result) {
     if (result) {
       console.log(result, "CACHE HIT!");
+      console.log("##vso[task.setvariable variable=cacheHit]true");
 
       if (options.downloadCacheOnHit) {
         downloadCache(hash, options.storageAccount, options.storageContainer, options.storageKey, options.outputPath).then(function () {
@@ -72,6 +73,7 @@ var hashAndCache = function (options) {
       }
     } else {
       console.log("CACHE MISS!");
+      console.log("##vso[task.setvariable variable=cacheHit]false");
       return onCacheMiss(hash, options);
     }
   });

--- a/src/vsts/buildAndReleaseTask/task.js
+++ b/src/vsts/buildAndReleaseTask/task.js
@@ -97,7 +97,7 @@ var runExecCommand = function (options) {
 var onCacheMiss = function (hash, options) {
   runExecCommand(options);
 
-  if (options.uploadCacheOnMiss) {
+  if (options.uploadCacheOnMiss && !options.skipExec) {
     var files = getFileList(options.outputPath, options.outputFiles, options.outputIgnore);
 
     if (!files || files.length == 0) {
@@ -131,6 +131,10 @@ var onCacheMiss = function (hash, options) {
         console.warn("Uploading of cache failed. This may happen when attempting to upload in parallel.")
         console.warn(err);
       });
+  } else {
+    if (options.skipExec) {
+      console.log("Skipping cache upload, no output to upload (options.skipExec = true)");
+    }
   }
 }
 

--- a/src/vsts/buildAndReleaseTask/task.js
+++ b/src/vsts/buildAndReleaseTask/task.js
@@ -34,7 +34,8 @@ var userOptions = {
   outputFiles: outputFiles.split(/\r?\n/),
   outputIgnore: outputIgnore.split(/\r?\n/),
   uploadCacheOnMiss: tl.getBoolInput('uploadCacheOnMiss'),
-  downloadCacheOnHit: tl.getBoolInput('downloadCacheOnHit')
+  downloadCacheOnHit: tl.getBoolInput('downloadCacheOnHit'),
+  skipExec: tl.getBoolInput('skipExec')
 }
 
 // calling this function prints all the variables if System.Debug == true
@@ -57,6 +58,7 @@ var hashAndCache = function (options) {
   options.outputFiles = typeof userOptions.outputFiles === 'string' ? [userOptions.outputFiles] : userOptions.outputFiles;
   options.downloadCacheOnHit = userOptions.downloadCacheOnHit === false ? false : true;
   options.uploadCacheOnMiss = userOptions.uploadCacheOnMiss === true;
+  options.skipExec = userOptions.skipExec === true? true : false;
 
   var hash = generateHash(options.sourcePath, options.sourceFiles, options.sourceIgnore, options.hashSuffix, options.execCommand);
 
@@ -80,11 +82,15 @@ var hashAndCache = function (options) {
 }
 
 var runExecCommand = function (options) {
-  if (options.execCommand) {
+  if (options.execCommand && !options.skipExec) {
     console.log("Running Command " + options.execCommand);
     execSync(options.execCommand, { cwd: options.execWorkingDirectory, stdio: 'inherit' });
   } else {
-    console.log("No command specified - skipping");
+    if (options.skipExec) {
+      console.log("Skipping exec command (options.skipExec = true)");
+    } else {
+      console.log("No command specified - skipping");
+    }
   }
 }
 


### PR DESCRIPTION
As described in documentation [here](https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md):

"Sets a variable in the variable service of taskcontext. The first task can set a variable, and following tasks in the same phase are able to use the variable. The variable is exposed to the following tasks as an environment variable. When issecret is set to true, the value of the variable will be saved as secret and masked out from log. Secret variables are not passed into tasks as environment variables and must be passed as inputs."
Examples:
`##vso[task.setvariable variable=testvar]testvalue`
`##vso[task.setvariable variable=testvar;issecret=true]testvalue`

This PR:
I would like this to be able to try the cache before committing to running the `execCommand`. Prep work can be done after this check in other tasks to prep for another run of the task where `execCommand` is then executed (And this work can be dependent on if there was a cache hit or not). `skipExec` option defaults to false. 